### PR TITLE
Include mbid in the album search results

### DIFF
--- a/src/lastfmapi/Api/AlbumApi.php
+++ b/src/lastfmapi/Api/AlbumApi.php
@@ -246,6 +246,7 @@ class AlbumApi extends BaseApi
                         $searchresults['results'][$i]['name'] = (string) $album->name;
                         $searchresults['results'][$i]['artist'] = (string) $album->artist;
                         $searchresults['results'][$i]['id'] = (string) $album->id;
+			$searchresults['results'][$i]['mbid'] = (string) $album->mbid;
                         $searchresults['results'][$i]['url'] = (string) $album->url;
                         $searchresults['results'][$i]['streamable'] = (string) $album->streamable;
                         $searchresults['results'][$i]['image']['small'] = (string) $album->image[0];


### PR DESCRIPTION
Ey!

I was trying your great API client and I noticed that 'mbid' is missing from the results of album search operation. 

Regards!