### PR TITLE
libxml_use_internal_errors set to false

### DIFF
--- a/src/lastfmapi/Api/BaseApi.php
+++ b/src/lastfmapi/Api/BaseApi.php
@@ -176,7 +176,7 @@ class BaseApi
             }
         }
         try {
-            libxml_use_internal_errors(true);
+            libxml_use_internal_errors(false);
             $xml = new SimpleXMLElement($xmlstr);
         } catch (\Exception $error) {
 


### PR DESCRIPTION
I am having this error:

<img width="967" alt="screen shot 2017-08-28 at 11 48 35 am" src="https://user-images.githubusercontent.com/1073799/29768525-e16682e8-8be6-11e7-92c8-589220ba0d06.png">

And it's because the response does not have the required "xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/" like is specified here https://www.last.fm/api/show/track.search for some reason. So it is not validating when creating SimpleXMLElement, 

If I disable libxml_use_internal_errors it simply works. 

I've tried also using str_replace to remove the "opensearch:" namespace but is terrible slow with big response.

Hope this helps!!

Regards!

