### PR TITLE
Update TrackApi.php - Scrobble multiple tracks in a batch

### DIFF
--- a/tests/Api/AuthenticatedTrackTest.php
+++ b/tests/Api/AuthenticatedTrackTest.php
@@ -45,7 +45,7 @@ class AuthenticatedTrackTest extends BaseAuthenticatedApiTest
         $this->assertTrue($result);        
     }    
     
-    public function testScrobble()
+    public function testScrobbleASingleTrack()
     {
         $result = $this->trackApi->scrobble(array(
             'artist' => self::ARTIST_NAME,
@@ -55,5 +55,23 @@ class AuthenticatedTrackTest extends BaseAuthenticatedApiTest
         );
 
         $this->assertTrue($result);        
-    }    
+    }
+
+    public function testScrobbleABatchOfTracks()
+    {
+        $result = $this->trackApi->scrobble(array(
+            array(
+                'artist' => self::ARTIST_NAME,
+                'track' => self::TRACK_NAME,
+                'timestamp' => time() - 60
+            ),
+            array(
+                'artist' => self::ARTIST_NAME,
+                'track' => self::TRACK_NAME,
+                'timestamp' => time() - 120
+            )
+        ));
+
+        $this->assertTrue($result);
+    }
 }


### PR DESCRIPTION
Updated TrackApi track.scrobble to allow scrobbling multiple tracks in a batch.

Method accept now also a multi dimensional array.
```php
$methodVars = [
    [
        'artist' => 'Artist',
        'track' => 'Track 1',
        'timestamp' => 123456780
    ],
    [
        'artist' => 'Artist',
        'track' => 'Track 2',
        'timestamp' => 123456789
    ]
];
```

This way each track could be validated for required variables and batch size.
Finally method variables  are converted in a singular array.

```php
$params = [
    'artist[0]' => 'Artist',
    'track[0]' => 'Track 1',
    'timestamp[0]' => 123456780,
    'artist[1]' => 'Artist',
    'track[1]' => 'Track 2',
    'timestamp[1]' => 123456789
];
``` 