### PR TITLE
Sqlite3 instead of outdated sqlite for cache

### DIFF
--- a/src/lastfmapi/Lib/Cache.php
+++ b/src/lastfmapi/Lib/Cache.php
@@ -163,7 +163,7 @@ class Cache
     public function get($unique_vars)
     {
         if ($this->enabled == true) {
-            $query = "SELECT expires, body FROM cache WHERE unique_vars='" . htmlentities(serialize($unique_vars), ENT_COMPAT, 'UTF-8') . "' LIMIT 1";
+            $query = "SELECT expires, body FROM cache WHERE unique_vars='" . htmlentities(serialize($unique_vars), ENT_QUOTES, 'UTF-8') . "' LIMIT 1";
             if ($result = $this->db->query($query)) {
                 if ($result->size() > 0) {
                     $row = $result->fetch();
@@ -171,8 +171,8 @@ class Cache
                         $this->del($unique_vars);
                         return false;
                     } else {
-                        //print_r(unserialize(html_entity_decode($row['body'], ENT_COMPAT, 'UTF-8')));
-                        return unserialize(html_entity_decode($row['body'], ENT_COMPAT, 'UTF-8'));
+                        //print_r(unserialize(html_entity_decode($row['body'], ENT_QUOTES, 'UTF-8')));
+                        return unserialize(html_entity_decode($row['body'], ENT_QUOTES, 'UTF-8'));
                     }
                 } else {
                     return false;
@@ -197,7 +197,7 @@ class Cache
     {
         if ($this->enabled == true) {
             $expire = time() + $this->config['cache_length'];
-            $query = "INSERT INTO cache (unique_vars, expires, body) VALUES ('" . htmlentities(serialize($unique_vars), ENT_COMPAT, 'UTF-8') . "', '" . $expire . "', \"" . htmlentities(serialize($body), ENT_COMPAT, 'UTF-8') . "\")";
+            $query = "INSERT INTO cache (unique_vars, expires, body) VALUES ('" . htmlentities(serialize($unique_vars), ENT_QUOTES, 'UTF-8') . "', '" . $expire . "', \"" . htmlentities(serialize($body), ENT_QUOTES, 'UTF-8') . "\")";
             if ($this->db->query($query)) {
                 return true;
             } else {
@@ -217,7 +217,7 @@ class Cache
      */
     private function del($unique_vars)
     {
-        $query = "DELETE FROM cache WHERE unique_vars='" . htmlentities(serialize($unique_vars), ENT_COMPAT, 'UTF-8') . "'";
+        $query = "DELETE FROM cache WHERE unique_vars='" . htmlentities(serialize($unique_vars), ENT_QUOTES, 'UTF-8') . "'";
         if ($this->db->query($query)) {
             return true;
         } else {

--- a/src/lastfmapi/Lib/Cache.php
+++ b/src/lastfmapi/Lib/Cache.php
@@ -73,7 +73,7 @@ class Cache
 
         if ($this->enabled == true) {
             if ($this->type == 'sqlite') {
-                $this->db = new Sqlite($this->config['path'] . 'phplastfmapi');
+                $this->db = new Sqlite($this->config['path'] . '/phplastfmapi.sqlite3');
             } else {
                 if (isset($this->config['database']['host']) && isset($this->config['database']['username']) && isset($this->config['database']['password']) && isset($this->config['database']['name'])) {
                     $this->db = new MySql($this->config['database']['host'], $this->config['database']['username'], $this->config['database']['password'], $this->config['database']['name']);
@@ -99,7 +99,7 @@ class Cache
      */
     private function check_if_enabled()
     {
-        if ($this->config['enabled'] == true && function_exists('sqlite_open')) {
+        if ($this->config['enabled'] == true && extension_loaded('sqlite3')) {
             $this->enabled = true;
         } else {
             $this->enabled = false;

--- a/src/lastfmapi/Lib/Sqlite.php
+++ b/src/lastfmapi/Lib/Sqlite.php
@@ -5,49 +5,14 @@ namespace LastFmApi\Lib;
 /**
  * Allows access to the sqlite database using a standard database class
  */
-class Sqlite
+class Sqlite extends \Sqlite3
 {
-
-    /**
-     * Stores the path to the database
-     * @var string
-     */
-    var $path;
-
-    /**
-     * Stores the connection status
-     * @var boolean
-     */
-    public $dbConn;
-
     /**
      * Stores the error details
      * @var array
      */
     public $error;
 
-    /**
-     * Constructor
-     * @param string $path The path to the database
-     * @return void
-     */
-    function __construct($path)
-    {
-        $this->path = $path;
-        $this->connectToDb();
-    }
-
-    /**
-     * Internal command to connect to the database
-     * @return void
-     */
-    function connectToDb()
-    {
-        if (!$this->dbConn = @sqlite_open($this->path, 0666, $this->error)) {
-
-            return false;
-        }
-    }
 
     /**
      * Method which runs queries. Returns a class on success and false on error
@@ -55,15 +20,9 @@ class Sqlite
      * @return class
      * @uses lastfmApiDatabase_result
      */
-    function & query($sql)
+    function query($sql)
     {
-        if (!$queryResource = sqlite_query($this->dbConn, $sql, SQLITE_BOTH, $this->error)) {
-            return false;
-        } else {
-            $result = new SqliteResult($this, $queryResource);
-
-            return $result;
-        }
+        return new SqliteResult(parent::query($sql));
     }
 
 }

--- a/src/lastfmapi/Lib/SqliteResult.php
+++ b/src/lastfmapi/Lib/SqliteResult.php
@@ -9,13 +9,6 @@ namespace LastFmApi\Lib;
  */
 class SqliteResult
 {
-
-    /**
-     * Stores the sqlite class
-     * @var class
-     */
-    var $sqlite;
-
     /**
      * Stores the query
      * @var class
@@ -28,9 +21,8 @@ class SqliteResult
      * @param class $query The query
      * @return void
      */
-    public function __construct(&$sqlite, $query)
+    public function __construct($query)
     {
-        $this->sqlite = &$sqlite;
         $this->query = $query;
     }
 
@@ -40,14 +32,7 @@ class SqliteResult
      */
     function fetch()
     {
-        if ($row = sqlite_fetch_array($this->query)) {
-            return $row;
-        } else if ($this->size() > 0) {
-            sqlite_seek($this->query, 0);
-            return false;
-        } else {
-            return false;
-        }
+        return $this->query->fetchArray();
     }
 
     /**
@@ -57,7 +42,7 @@ class SqliteResult
     function fetchAll()
     {
         $result = array();
-        while ($row = sqlite_fetch_array($this->query)) {
+        while ($row = $this->fetch()) {
             $result[] = $row;
         }
         return $result;
@@ -69,7 +54,7 @@ class SqliteResult
      */
     function size()
     {
-        return sqlite_num_rows($this->query);
+        return $this->query->numColumns();
     }
 
 }


### PR DESCRIPTION
This patch replaces outdated sqlite php extension with Sqlite3 for cache. I can't even compile sqlite2 on modern linux.